### PR TITLE
Extend MatchQuery parameters & Add WildcardQuery and Suggesters

### DIFF
--- a/effdsl.go
+++ b/effdsl.go
@@ -20,6 +20,12 @@ type (
 	RangeQueryOption   = objs.RangeQueryOption
 	TermQueryOption    = objs.TermQueryOption
 	SourceFitlerOption = objs.SourceFitlerOption
+
+	MatchOperator = objs.MatchOperator
+	Fuzziness     = objs.Fuzziness
+
+	WildcardQueryFieldParameter = objs.WildcardQueryFieldParameter
+	RewriteParameter            = objs.RewriteParameter
 )
 
 //--------------------------------------------------------------------------------------//
@@ -53,9 +59,13 @@ var (
 	WithTranspositions = objs.WithTranspositions
 	FuzzyQuery         = objs.FuzzyQuery
 	// q_match_query.go
-	MatchQuery = objs.MatchQuery
+	MatchQuery             = objs.MatchQuery
+	WithMatchOperator      = objs.WithMatchOperator
+	WithFuzzinessParameter = objs.WithFuzzinessParameter
 	// q_wildcard_query.go
-	WildcardQuery = objs.WildcardQuery
+	WildcardQuery        = objs.WildcardQuery
+	WithBoost            = objs.WithBoost
+	WithRewriteParameter = objs.WithRewriteParameter
 	// q_query_string.go
 	WithFields          = objs.WithFields
 	WithAnalyzeWildcard = objs.WithAnalyzeWildcard
@@ -99,4 +109,17 @@ const (
 	SORT_DEFAULT objs.SortOrder = objs.SORT_DEFAULT
 	SORT_ASC     objs.SortOrder = objs.SORT_ASC
 	SORT_DESC    objs.SortOrder = objs.SORT_DESC
+
+	MatchOperatorOR  objs.MatchOperator = objs.MatchOperatorOR
+	MatchOperatorAND objs.MatchOperator = objs.MatchOperatorAND
+
+	FuzzinessAUTO objs.Fuzziness = objs.FuzzinessAUTO
+
+	RewriteParameterConstantScoreBlended  objs.RewriteParameter = objs.RewriteParameterConstantScoreBlended
+	RewriteParameterConstantScore         objs.RewriteParameter = objs.RewriteParameterConstantScore
+	RewriteParameterConstantScoreBoolean  objs.RewriteParameter = objs.RewriteParameterConstantScoreBoolean
+	RewriteParameterScoringBoolean        objs.RewriteParameter = objs.RewriteParameterScoringBoolean
+	RewriteParameterTopTermsBlendedFreqsN objs.RewriteParameter = objs.RewriteParameterTopTermsBlendedFreqsN
+	RewriteParameterTopTermsBoostN        objs.RewriteParameter = objs.RewriteParameterTopTermsBoostN
+	RewriteParameterTopTermsN             objs.RewriteParameter = objs.RewriteParameterTopTermsN
 )

--- a/effdsl.go
+++ b/effdsl.go
@@ -28,6 +28,9 @@ type (
 	RewriteParameter            = objs.RewriteParameter
 
 	SortOrder = objs.SortOrder
+
+	SuggestSort = objs.SuggestSort
+	SuggestMode = objs.SuggestMode
 )
 
 //--------------------------------------------------------------------------------------//
@@ -101,6 +104,16 @@ var (
 	WithIncludes = objs.WithIncludes
 	WithExcludes = objs.WithExcludes
 	SourceFilter = objs.SourceFilter
+
+	// search_source_filtering.go
+	Suggesters              = objs.Suggesters
+	WithSuggest             = objs.WithSuggest
+	TermSuggester           = objs.TermSuggester
+	Term                    = objs.Term
+	WithTermSuggestAnalyzer = objs.WithTermSuggestAnalyzer
+	WithTermSuggestSize     = objs.WithTermSuggestSize
+	WithTermSuggestSort     = objs.WithTermSuggestSort
+	WithTermSuggestMode     = objs.WithTermSuggestMode
 )
 
 //--------------------------------------------------------------------------------------//

--- a/effdsl.go
+++ b/effdsl.go
@@ -54,6 +54,8 @@ var (
 	FuzzyQuery         = objs.FuzzyQuery
 	// q_match_query.go
 	MatchQuery = objs.MatchQuery
+	// q_wildcard_query.go
+	WildcardQuery = objs.WildcardQuery
 	// q_query_string.go
 	WithFields          = objs.WithFields
 	WithAnalyzeWildcard = objs.WithAnalyzeWildcard

--- a/effdsl.go
+++ b/effdsl.go
@@ -26,6 +26,8 @@ type (
 
 	WildcardQueryFieldParameter = objs.WildcardQueryFieldParameter
 	RewriteParameter            = objs.RewriteParameter
+
+	SortOrder = objs.SortOrder
 )
 
 //--------------------------------------------------------------------------------------//

--- a/objects/q_match_query.go
+++ b/objects/q_match_query.go
@@ -5,8 +5,10 @@ import (
 )
 
 type MatchQueryS struct {
-	Field string `json:"-"`     //(Required, object) Field you wish to search.
-	Query string `json:"query"` //(Required) Text, number, boolean value or date you wish to find in the provided <field>.
+	Field     string `json:"-"`                   // (Required, object) Field you wish to search.
+	Query     string `json:"query"`               // (Required) Text, number, boolean value or date you wish to find in the provided <field>.
+	Operator  string `json:"operator,omitempty"`  // (Optional, string) Boolean logic used to interpret text in the query value.
+	Fuzziness string `json:"fuzziness,omitempty"` // (Optional, string) Maximum edit distance allowed for matching.
 }
 
 func (mq MatchQueryS) QueryInfo() string {
@@ -24,13 +26,69 @@ func (mq MatchQueryS) MarshalJSON() ([]byte, error) {
 	)
 }
 
+type MatchOperator string
+
+const (
+	MatchOperatorOR  MatchOperator = "OR"
+	MatchOperatorAND MatchOperator = "AND"
+)
+
+type Fuzziness string
+
+const (
+	FuzzinessAUTO Fuzziness = "AUTO"
+)
+
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#match-field-params
+type matchQueryFieldParameters struct {
+	/*
+		(Optional, string) Boolean logic used to interpret text in the query value. Valid values are:
+
+		* OR (Default)
+			* For example, a query value of capital of Hungary is interpreted as capital OR of OR Hungary.
+		* AND
+			* For example, a query value of capital of Hungary is interpreted as capital AND of AND Hungary.
+	*/
+	Operator MatchOperator
+
+	/*
+		(Optional, string) Maximum edit distance allowed for matching. See [Fuzziness](https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#fuzziness) for valid values and more information.
+	*/
+	Fuzziness Fuzziness
+}
+
+type MatchQueryFieldParameter func(prms *matchQueryFieldParameters)
+
+// WithMatchOperator ...
+func WithMatchOperator(op MatchOperator) MatchQueryFieldParameter {
+	return func(prms *matchQueryFieldParameters) {
+		prms.Operator = op
+	}
+}
+
+// WithFuzzinessParameter ...
+func WithFuzzinessParameter(f Fuzziness) MatchQueryFieldParameter {
+	return func(prms *matchQueryFieldParameters) {
+		prms.Fuzziness = f
+	}
+}
+
 // Returns documents that match a provided text, number, date or boolean value. The provided text is analyzed before matching.
 // [Match query]: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html
-func MatchQuery(field string, query string) QueryResult {
+func MatchQuery(field string, query string, prms ...MatchQueryFieldParameter) QueryResult {
 	matchQuery := MatchQueryS{
 		Field: field,
 		Query: query,
 	}
+
+	var parameters matchQueryFieldParameters
+	for _, prm := range prms {
+		prm(&parameters)
+	}
+
+	matchQuery.Operator = string(parameters.Operator)
+	matchQuery.Fuzziness = string(parameters.Fuzziness)
+
 	return QueryResult{
 		Ok:  matchQuery,
 		Err: nil,

--- a/objects/q_match_query_test.go
+++ b/objects/q_match_query_test.go
@@ -1,0 +1,20 @@
+package objects
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_MatchQueryS_MarshalJSON(t *testing.T) {
+	q := MatchQuery("field_name", "some match query",
+		WithMatchOperator(MatchOperatorAND),
+		WithFuzzinessParameter(FuzzinessAUTO),
+	)
+
+	body, err := q.Ok.MarshalJSON()
+	require.NoError(t, err)
+
+	const expected = `{"match":{"field_name":{"query":"some match query","operator":"AND","fuzziness":"AUTO"}}}`
+	require.Equal(t, expected, string(body))
+}

--- a/objects/q_range_query.go
+++ b/objects/q_range_query.go
@@ -73,7 +73,7 @@ func RangeQuery(field string, opts ...RangeQueryOption) QueryResult {
 	if rangeQuery.GT == nil && rangeQuery.GTE == nil && rangeQuery.LT == nil && rangeQuery.LTE == nil {
 		return QueryResult{
 			Ok:  rangeQuery,
-			Err: errors.New("One of WithGT, WithGTE, WithLT, WithLTE should be proveded for range query"),
+			Err: errors.New("one of WithGT, WithGTE, WithLT, WithLTE should be proveded for range query"),
 		}
 	}
 	return QueryResult{

--- a/objects/q_wildcard_query.go
+++ b/objects/q_wildcard_query.go
@@ -1,0 +1,96 @@
+package objects
+
+import (
+	"encoding/json"
+)
+
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+type WildcardQueryS struct {
+	Field   string  `json:"-"`                 // (Required, object) Field you wish to search.
+	Value   string  `json:"value"`             // (Required, string) Wildcard pattern for terms you wish to find in the provided <field>.
+	Boost   float32 `json:"boost,omitempty"`   // (Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.
+	Rewrite string  `json:"rewrite,omitempty"` // (Optional, string) Method used to rewrite the query. For valid values and more information, see the rewrite parameter.
+}
+
+func (wq WildcardQueryS) QueryInfo() string {
+	return "Wildcard query"
+}
+
+func (wq WildcardQueryS) MarshalJSON() ([]byte, error) {
+	type WildcardQuerySBase WildcardQueryS
+	return json.Marshal(
+		M{
+			"wildcard": M{
+				wq.Field: (WildcardQuerySBase)(wq),
+			},
+		},
+	)
+}
+
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-term-rewrite.html
+type RewriteParameter string
+
+const (
+	RewriteParameterConstantScoreBlended  RewriteParameter = "constant_score_blended"
+	RewriteParameterConstantScore         RewriteParameter = "constant_score"
+	RewriteParameterConstantScoreBoolean  RewriteParameter = "constant_score_boolean"
+	RewriteParameterScoringBoolean        RewriteParameter = "scoring_boolean"
+	RewriteParameterTopTermsBlendedFreqsN RewriteParameter = "top_terms_blended_freqs_N"
+	RewriteParameterTopTermsBoostN        RewriteParameter = "top_terms_boost_N"
+	RewriteParameterTopTermsN             RewriteParameter = "top_terms_N"
+)
+
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html#wildcard-query-field-params
+type wildcardQueryFieldParameters struct {
+	/*
+		(Optional, float) Floating point number used to decrease or increase the relevance scores of a query. Defaults to 1.0.
+
+		You can use the boost parameter to adjust relevance scores for searches containing two or more queries.
+
+		Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.
+	*/
+	Boost float32
+
+	/*
+		(Optional, string) Method used to rewrite the query. For valid values and more information, see the rewrite parameter.
+	*/
+	RewriteParameter RewriteParameter
+}
+
+type WildcardQueryFieldParameter func(prms *wildcardQueryFieldParameters)
+
+// WithBoost ...
+func WithBoost(boost float32) WildcardQueryFieldParameter {
+	return func(prms *wildcardQueryFieldParameters) {
+		prms.Boost = boost
+	}
+}
+
+// WithRewriteParameter ...
+func WithRewriteParameter(rwp RewriteParameter) WildcardQueryFieldParameter {
+	return func(prms *wildcardQueryFieldParameters) {
+		prms.RewriteParameter = rwp
+	}
+}
+
+// Returns documents that contain terms matching a wildcard pattern.
+// [Wildcard query]: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+func WildcardQuery(field string, value string, prms ...WildcardQueryFieldParameter) QueryResult {
+	wildcardQuery := WildcardQueryS{
+		Field: field,
+		Value: value,
+	}
+
+	var parameters wildcardQueryFieldParameters
+	for _, prm := range prms {
+		prm(&parameters)
+	}
+
+	wildcardQuery.Boost = parameters.Boost
+	wildcardQuery.Rewrite = string(parameters.RewriteParameter)
+
+	return QueryResult{
+		Ok:  wildcardQuery,
+		Err: nil,
+	}
+}

--- a/objects/q_wildcard_query_test.go
+++ b/objects/q_wildcard_query_test.go
@@ -1,0 +1,20 @@
+package objects
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_WildcardQueryS_MarshalJSON(t *testing.T) {
+	q := WildcardQuery("field_name", "some match query",
+		WithBoost(1.0),
+		WithRewriteParameter(RewriteParameterConstantScore),
+	)
+
+	body, err := q.Ok.MarshalJSON()
+	require.NoError(t, err)
+
+	const expected = `{"wildcard":{"field_name":{"value":"some match query","boost":1,"rewrite":"constant_score"}}}`
+	require.Equal(t, expected, string(body))
+}

--- a/objects/search_source_filtering.go
+++ b/objects/search_source_filtering.go
@@ -3,8 +3,8 @@ package objects
 import "encoding/json"
 
 type SourceFilterS struct {
-	Includes []string `json:"includes,ommitempty"`
-	Excludes []string `json:"excludes,ommitempty"`
+	Includes []string `json:"includes,omitempty"`
+	Excludes []string `json:"excludes,omitempty"`
 }
 
 func (sf SourceFilterS) MarshalJSON() ([]byte, error) {

--- a/objects/search_suggest.go
+++ b/objects/search_suggest.go
@@ -1,0 +1,152 @@
+package objects
+
+import "encoding/json"
+
+type SuggestS struct {
+	GlobalText string `json:"text,omitempty"` // To avoid repetition of the suggest text, it is possible to define a global text.
+	Suggester
+}
+
+func (s SuggestS) MarshalJSON() ([]byte, error) {
+	type SuggesterBase SuggestS
+	return json.Marshal((SuggesterBase)(s))
+}
+
+func (s SuggestS) SuggestInfo() string {
+	return "Suggest"
+}
+
+// Suggests similar looking terms based on a provided text by using a suggester.
+// [Suggesters]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#search-suggesters
+func Suggesters(globalText string, s Suggester) SuggestResult {
+	sugest := SuggestS{
+		GlobalText: globalText,
+		Suggester:  s,
+	}
+
+	return SuggestResult{
+		Ok:  sugest,
+		Err: nil,
+	}
+}
+
+// ----------------------------------------------------
+
+type Suggester interface {
+	json.Marshaler
+	_type() string
+}
+
+// ----------------------------------------------------
+
+// TermSuggester - https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#term-suggester
+type TermsSuggest []TermSuggest
+
+func (ts TermsSuggest) MarshalJSON() ([]byte, error) {
+	type TermSuggesterBase TermSuggest
+
+	terms := make(M, len(ts))
+	for i := range ts {
+		terms[ts[i].GetName()] = (TermSuggesterBase)(ts[i])
+	}
+
+	return json.Marshal(terms)
+}
+
+func (ts TermsSuggest) _type() string {
+	return "term suggester"
+}
+
+type TermSuggesterS struct {
+	Name string `json:"-"`              //
+	Text string `json:"text,omitempty"` // The suggest text. The suggest text is a required option that needs to be set globally or per suggestion.
+	Term TermS  `json:"term"`           // (Required) The term suggester suggests terms based on edit distance. The provided suggest text is analyzed before terms are suggested. The suggested terms are provided per analyzed suggest text token. The term suggester doesn’t take the query into account that is part of request.
+}
+
+func (t TermSuggesterS) GetName() string {
+	return t.Name
+}
+
+type TermS struct {
+	Field       string      `json:"field"`              // The field to fetch the candidate suggestions from. This is a required option that either needs to be set globally or per suggestion.
+	Analyzer    string      `json:"analyzer,omitempty"` // The analyzer to analyse the suggest text with. Defaults to the search analyzer of the suggest field.
+	Size        int         `json:"size,omitempty"`     // The maximum corrections to be returned per suggest text token.
+	Sort        SuggestSort `json:"sort,omitempty"`     // Defines how suggestions should be sorted per suggest text term. Two possible values: score, frequency
+	SuggestMode SuggestMode `json:"suggest_mode,omitempty"`
+}
+
+// SuggestSort - Defines how suggestions should be sorted per suggest text term.
+type SuggestSort string
+
+const (
+	// SortScore - Sort by score first, then document frequency and then the term itself.
+	SortScore SuggestSort = "score"
+	// FrequencyScore - Sort by document frequency first, then similarity score and then the term itself.
+	FrequencyScore SuggestSort = "frequency"
+)
+
+// SuggestMode - The suggest mode controls what suggestions are included or controls
+// for what suggest text terms, suggestions should be suggested.
+type SuggestMode string
+
+const (
+	// SuggestModeMissing - Only provide suggestions for suggest text terms that are not in the index (default).
+	SuggestModeMissing SuggestMode = "score"
+	// SuggestModePopular - Only suggest suggestions that occur in more docs than the original suggest text term.
+	SuggestModePopular SuggestMode = "popular"
+	// Suggest any matching suggestions based on terms in the suggest text.
+	SuggestModeAlways SuggestMode = "always"
+)
+
+type TermSuggestOption func(*TermS)
+
+func WithTermSuggestAnalyzer(analyzer string) TermSuggestOption {
+	return func(termSuggest *TermS) {
+		termSuggest.Analyzer = analyzer
+	}
+}
+
+func WithTermSuggestSize(size int) TermSuggestOption {
+	return func(termSuggest *TermS) {
+		termSuggest.Size = size
+	}
+}
+
+func WithTermSuggestSort(sort SuggestSort) TermSuggestOption {
+	return func(termSuggest *TermS) {
+		termSuggest.Sort = sort
+	}
+}
+
+func WithTermSuggestMode(mode SuggestMode) TermSuggestOption {
+	return func(termSuggest *TermS) {
+		termSuggest.SuggestMode = mode
+	}
+}
+
+func Term(name, text, field string, opts ...TermSuggestOption) TermSuggest {
+	s := TermSuggesterS{
+		Name: name,
+		Text: text,
+		Term: TermS{
+			Field: field,
+		},
+	}
+	for _, opt := range opts {
+		opt(&s.Term)
+	}
+	return s
+}
+
+type TermSuggest interface {
+	GetName() string
+}
+
+// TermSuggester - https://www.elastic.co/guide/en/elasticsearch/reference/current/search-suggesters.html#term-suggester
+func TermSuggester(terms ...TermSuggest) Suggester {
+	v := make(TermsSuggest, 0, len(terms))
+	for i := range terms {
+		v = append(v, terms[i])
+	}
+	return v
+}

--- a/objects/search_suggest.go
+++ b/objects/search_suggest.go
@@ -9,7 +9,11 @@ type SuggestS struct {
 
 func (s SuggestS) MarshalJSON() ([]byte, error) {
 	type SuggesterBase SuggestS
-	return json.Marshal((SuggesterBase)(s))
+	return json.Marshal(
+		M{
+			"suggest": (SuggesterBase)(s),
+		},
+	)
 }
 
 func (s SuggestS) SuggestInfo() string {

--- a/objects/search_suggest_test.go
+++ b/objects/search_suggest_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Searhc_Suggest_MarshalJSON(t *testing.T) {
+func Test_Search_Suggest_MarshalJSON(t *testing.T) {
 	s := Suggesters("test", TermSuggester(
 		Term("my-suggestion-1", "tring out Elasticsearch", "message"),
 		Term("my-suggestion-2", "tring out Elasticsearch", "message",

--- a/objects/search_suggest_test.go
+++ b/objects/search_suggest_test.go
@@ -1,0 +1,25 @@
+package objects
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Searhc_Suggest_MarshalJSON(t *testing.T) {
+	s := Suggesters("test", TermSuggester(
+		Term("my-suggestion-1", "tring out Elasticsearch", "message"),
+		Term("my-suggestion-2", "tring out Elasticsearch", "message",
+			WithTermSuggestMode(SuggestModeAlways),
+			WithTermSuggestAnalyzer("test"),
+			WithTermSuggestSize(1),
+			WithTermSuggestSort(SortScore),
+		),
+	))
+
+	body, err := s.Ok.MarshalJSON()
+	require.NoError(t, err)
+
+	const expected = `{"suggest":{"my-suggestion-1":{"text":"tring out Elasticsearch","term":{"field":"message"}},"my-suggestion-2":{"text":"tring out Elasticsearch","term":{"field":"message","analyzer":"test","size":1,"sort":"score","suggest_mode":"always"}}}}`
+	require.Equal(t, expected, string(body))
+}


### PR DESCRIPTION
I'd like to use optional match query parameters. This is an example how to extend library. But unfortunately the changes are not backwards compatible.

Later you can easily add new parameters from https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-query.html#match-field-params