### PR TITLE
DOC: Update 'Go Reference' badge in README.md to v2 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # effdsl
 
 ![GitHub Release](https://img.shields.io/github/v/release/sdqri/effdsl)
-[![GoDoc](https://pkg.go.dev/badge/github.com/sdqri/effdsl?status.svg)](https://pkg.go.dev/github.com/sdqri/effdsl?tab=doc)
+[![GoDoc](https://pkg.go.dev/badge/github.com/sdqri/effdsl/v2?status.svg)](https://pkg.go.dev/github.com/sdqri/effdsl/v2?tab=doc)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sdqri/effdsl)](https://goreportcard.com/report/github.com/sdqri/effdsl)
 ![GitHub License](https://img.shields.io/github/license/sdqri/effdsl)
 <a href="https://github.com/sdqri/effdsl/pulls" style="text-decoration: none;"><img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat" alt="Contributions welcome"></a>


### PR DESCRIPTION
This PR points the 'Go reference' badge in the README to the `v2` documentation on `pkg.go.dev`.

## Description

- [ ] Bug fix
- [ ] Feature addition
- [ ] Code refactoring
- [x] Documentation update
- [ ] Other (please explain):

## How Has This Been Tested?

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that ensure my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.