### PR TITLE
FIX: typofix in function name WithCollapse

### DIFF
--- a/effdsl.go
+++ b/effdsl.go
@@ -140,9 +140,14 @@ func WithSort(sortClauseResults ...SortClauseResult) BodyOption {
 	}
 }
 
+// Deprecated: use WithCollapse
+func WithCollpse(field string) BodyOption {
+	return WithCollapse(field)
+}
+
 // You can use the collapse parameter to collapse search results based on field values. The collapsing is done by selecting only the top sorted document per collapse key.
 // [Collapse search results]: https://www.elastic.co/guide/en/elasticsearch/reference/current/collapse-search-results.html
-func WithCollpse(field string) BodyOption {
+func WithCollapse(field string) BodyOption {
 	searchCollapse := Collapse(field)
 	return func(sb *SearchBody) error {
 		sb.Collapse = searchCollapse


### PR DESCRIPTION
This PR renames the function `WithCollpse` to `WithCollapse` and provides backwards compatibility by keeping the old function name intact as well.

## Description

- [ ] Bug fix
- [ ] Feature addition
- [x] Code refactoring
- [ ] Documentation update
- [ ] Other (please explain):

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have made corresponding changes to the documentation.
- [ ] I have added tests that ensure my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.