### PR TITLE
Support nested queries

### DIFF
--- a/queries/nestedquery/nested_query.go
+++ b/queries/nestedquery/nested_query.go
@@ -1,0 +1,68 @@
+package nestedquery
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/sdqri/effdsl/v2"
+)
+
+// NestedQueryS Wraps another query to search nested fields.
+// The nested query searches nested field objects as if they were indexed as separate documents.
+// If an object matches the search, the nested query returns the root parent document.
+type NestedQueryS struct {
+	Path           string       `json:"path"`                      // (Required, string) Path to the nested object you wish to search.
+	Query          effdsl.Query `json:"query"`                     // (Required, effdsl.Query) Nested field query.
+	ScoreMode      string       `json:"score_mode,omitempty"`      // (Optional, string) Indicates how scores for matching child objects affect the root parent document’s relevance score.
+	IgnoreUnmapped bool         `json:"ignore_unmapped,omitempty"` // (Optional, Boolean) Indicates whether to ignore an unmapped path and not return any documents instead of an error.
+}
+
+func (nq NestedQueryS) QueryInfo() string {
+	return "Nested query"
+}
+
+func (nq NestedQueryS) MarshalJSON() ([]byte, error) {
+	type NestedQueryBase NestedQueryS
+	return json.Marshal(
+		effdsl.M{
+			"nested": (NestedQueryBase)(nq),
+		},
+	)
+}
+
+type NestedQueryOption func(*NestedQueryS)
+
+func WithNested(path string, qr effdsl.QueryResult, opts ...NestedQueryOption) effdsl.QueryResult {
+	if qr.Err != nil {
+		return effdsl.QueryResult{
+			Ok:  nil,
+			Err: fmt.Errorf("nested `%s`: %w", path, qr.Err),
+		}
+	}
+
+	nq := NestedQueryS{
+		Path:  path,
+		Query: qr.Ok,
+	}
+
+	for _, opt := range opts {
+		opt(&nq)
+	}
+
+	return effdsl.QueryResult{
+		Ok:  nq,
+		Err: nil,
+	}
+}
+
+func WithScoreMode(scoreMode string) NestedQueryOption {
+	return func(params *NestedQueryS) {
+		params.ScoreMode = scoreMode
+	}
+}
+
+func WithIgnoreUnmapped(ignoreUnmapped bool) NestedQueryOption {
+	return func(params *NestedQueryS) {
+		params.IgnoreUnmapped = ignoreUnmapped
+	}
+}

--- a/queries/nestedquery/nested_query_test.go
+++ b/queries/nestedquery/nested_query_test.go
@@ -1,0 +1,106 @@
+package nestedquery_test
+
+import (
+	"encoding/json"
+	"github.com/sdqri/effdsl/v2"
+	bq "github.com/sdqri/effdsl/v2/queries/boolquery"
+	mq "github.com/sdqri/effdsl/v2/queries/matchquery"
+	nq "github.com/sdqri/effdsl/v2/queries/nestedquery"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNestedQuery_InQuery(t *testing.T) {
+	expectedBody := `{
+  "query": {
+    "nested": {
+      "path": "path",
+      "query": {
+        "bool": {
+          "should": [
+            {
+              "match": {
+                "field1": {
+                  "query": "val1"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "score_mode": "avg",
+      "ignore_unmapped": true
+    }
+  }
+}`
+	query, err := effdsl.Define(
+		effdsl.WithQuery(
+			nq.WithNested(
+				"path",
+				bq.BoolQuery(
+					bq.Should(
+						mq.MatchQuery("field1", "val1"),
+					),
+				),
+				nq.WithScoreMode("avg"),
+				nq.WithIgnoreUnmapped(true),
+			),
+		),
+	)
+
+	jsonBody, err := json.MarshalIndent(query, "", "  ")
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBody, string(jsonBody))
+}
+
+func TestNestedQuery_InBool(t *testing.T) {
+	expectedBody := `{
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "nested": {
+            "path": "path",
+            "query": {
+              "bool": {
+                "should": [
+                  {
+                    "match": {
+                      "field1": {
+                        "query": "val1"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}`
+	query, err := effdsl.Define(
+		effdsl.WithQuery(
+			bq.BoolQuery(
+				bq.Must(
+					nq.WithNested(
+						"path",
+						bq.BoolQuery(
+							bq.Should(
+								mq.MatchQuery("field1", "val1"),
+							),
+						),
+					),
+				),
+			),
+		),
+	)
+
+	jsonBody, err := json.MarshalIndent(query, "", "  ")
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBody, string(jsonBody))
+}


### PR DESCRIPTION
## Pull Request Title
Add support for Nested queries

## Description
This PR introduces the `NestedQueryS` struct, which implements the [Nested Query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html) in Elasticsearch.  
The `NestedQueryS` allows querying nested objects efficiently while preserving their hierarchical structure.  
## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that ensure my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

