### PR TITLE
Add missing to sort order

### DIFF
--- a/effdsl_test.go
+++ b/effdsl_test.go
@@ -174,7 +174,7 @@ func TestDefindeQ1(t *testing.T) {
 		},
 		"sort":[
 		   {
-			  "sort_field1":"desc"
+			  "sort_field1":{"order": "desc"}
 		   },
 		   "_score"
 		],

--- a/search_sort.go
+++ b/search_sort.go
@@ -1,6 +1,10 @@
 package effdsl
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/sdqri/effdsl/v2/utils"
+)
 
 type SortOrder string
 
@@ -10,32 +14,65 @@ const (
 	SORT_DESC    SortOrder = "desc"
 )
 
+const (
+	MISSING_FIRST = "_first"
+	MISSING_LAST  = "_last"
+)
+
 type SortClauseS struct {
-	Field string    `json:"-"`
-	Order SortOrder `json:"-"`
+	Field   string    `json:"-"`
+	Order   SortOrder `json:"order,omitempty"`
+	Missing *string   `json:"missing,omitempty"`
 }
 
 func (sq SortClauseS) SortClauseInfo() string {
 	return "Sort clause"
 }
 
+type sortClauseParameters struct {
+	/*
+			(Optional, string) The missing parameter specifies how docs which are missing the sort field should be treated:
+		 The missing value can be set to _last, _first, or a custom value (that will be used for missing docs as the sort value). The default is _last.
+	*/
+	Missing *string `json:"missing,omitempty"`
+}
+type SortClauseParameter func(params *sortClauseParameters)
+
 func (sq SortClauseS) MarshalJSON() ([]byte, error) {
-	if sq.Order == SORT_DEFAULT {
+	if sq.Order == SORT_DEFAULT && sq.Missing == nil {
 		return json.Marshal(sq.Field)
 	}
+	params := M{}
+	if sq.Order != SORT_DEFAULT {
+		params["order"] = sq.Order
+	}
+	if sq.Missing != nil {
+		params["missing"] = *sq.Missing
+	}
 	tmpM := M{
-		sq.Field: sq.Order,
+		sq.Field: params,
 	}
 	return json.Marshal(tmpM)
 }
 
-func SortClause(field string, order SortOrder) SortClauseResult {
-	sortClause := SortClauseS{
-		Field: field,
-		Order: order,
+func WithMissing(missing string) SortClauseParameter {
+	return func(params *sortClauseParameters) {
+		params.Missing = &missing
 	}
+}
+
+func SortClause(field string, order SortOrder, params ...SortClauseParameter) SortClauseResult {
+	var parameters sortClauseParameters
+	sortClause := SortClauseS{}
+	for _, prm := range params {
+		prm(&parameters)
+	}
+
+	sortClause, err := utils.CastStruct[sortClauseParameters, SortClauseS](parameters)
+	sortClause.Field = field
+	sortClause.Order = order
 	return SortClauseResult{
 		Ok:  sortClause,
-		Err: nil,
+		Err: err,
 	}
 }

--- a/search_sort_test.go
+++ b/search_sort_test.go
@@ -21,7 +21,7 @@ func TestNewSortClauseWithDefaultOrder(t *testing.T) {
 }
 
 func TestNewSortClauseWithOrder(t *testing.T) {
-	expectedBody := `{"fake_field":"asc"}`
+	expectedBody := `{"fake_field":{"order":"asc"}}`
 	sortClauseResult := effdsl.SortClause("fake_field", effdsl.SORT_ASC)
 	err := sortClauseResult.Err
 	sortClause := sortClauseResult.Ok
@@ -29,4 +29,58 @@ func TestNewSortClauseWithOrder(t *testing.T) {
 	jsonBody, err := json.Marshal(sortClause)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedBody, string(jsonBody))
+}
+
+func TestNewSortClauseWithOrderAndMissing(t *testing.T) {
+	tests := []struct {
+		name     string
+		field    string
+		order    effdsl.SortOrder
+		opts     []effdsl.SortClauseParameter
+		expected string
+	}{
+		{
+			name:     "only order asc",
+			order:    effdsl.SORT_ASC,
+			field:    "price",
+			expected: `{"price":{"order":"asc"}}`,
+		},
+		{
+			name:     "order desc with missing last",
+			order:    effdsl.SORT_DESC,
+			field:    "date",
+			opts:     []effdsl.SortClauseParameter{effdsl.WithMissing(effdsl.MISSING_LAST)},
+			expected: `{"date":{"order":"desc","missing":"_last"}}`,
+		},
+		{
+			name:     "custom missing value",
+			field:    "rating",
+			order:    effdsl.SORT_DEFAULT,
+			opts:     []effdsl.SortClauseParameter{effdsl.WithMissing("0")},
+			expected: `{"rating":{"missing":"0"}}`,
+		},
+		{
+			name:     "default order with missing first",
+			field:    "category",
+			order:    effdsl.SORT_DEFAULT,
+			opts:     []effdsl.SortClauseParameter{effdsl.WithMissing(effdsl.MISSING_FIRST)},
+			expected: `{"category":{"missing":"_first"}}`,
+		},
+		{
+			name:     "no parameters",
+			field:    "quantity",
+			order:    effdsl.SORT_DEFAULT,
+			opts:     nil,
+			expected: `"quantity"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortClause := effdsl.SortClause(tt.field, tt.order, tt.opts...)
+			jsonBody, err := json.Marshal(sortClause.Ok)
+			assert.NoError(t, err)
+			assert.JSONEq(t, tt.expected, string(jsonBody))
+		})
+	}
 }


### PR DESCRIPTION
## Add "missing" parameter to sorting

Add "missing" parameter to sorting according to documentation https://www.elastic.co/guide/en/elasticsearch/reference/current/sort-search-results.html#_missing_values

## Description

- [ ] Bug fix
- [x] Feature addition
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Other (please explain):


## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that ensure my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
