### PR TITLE
Add aggregation support

### DIFF
--- a/effdsl.go
+++ b/effdsl.go
@@ -12,16 +12,17 @@ func (m M) MarshalJSON() ([]byte, error) {
 }
 
 type SearchBody struct {
-	Source      json.Marshaler   `json:"_source,omitempty"`
-	From        *uint64          `json:"from,omitempty"`
-	Size        *uint64          `json:"size,omitempty"`
-	Query       Query            `json:"query,omitempty"`
-	Sort        []SortClauseType `json:"sort,omitempty"`
-	TrackScore  bool             `json:"track_scores,omitempty"`
-	SearchAfter SearchAfterType  `json:"search_after,omitempty"`
-	Collapse    json.Marshaler   `json:"collapse,omitempty"`
-	PIT         json.Marshaler   `json:"pit,omitempty"`
-	Suggest     Suggest          `json:"suggest,omitempty"`
+	Source       json.Marshaler         `json:"_source,omitempty"`
+	From         *uint64                `json:"from,omitempty"`
+	Size         *uint64                `json:"size,omitempty"`
+	Query        Query                  `json:"query,omitempty"`
+	Sort         []SortClauseType       `json:"sort,omitempty"`
+	TrackScore   bool                   `json:"track_scores,omitempty"`
+	SearchAfter  SearchAfterType        `json:"search_after,omitempty"`
+	Collapse     json.Marshaler         `json:"collapse,omitempty"`
+	PIT          json.Marshaler         `json:"pit,omitempty"`
+	Suggest      Suggest                `json:"suggest,omitempty"`
+	Aggregations map[string]Aggregation `json:"aggs,omitempty"`
 }
 
 type BodyOption func(*SearchBody) error
@@ -205,5 +206,23 @@ func WithSuggest(suggestResult SuggestResult) BodyOption {
 	return func(b *SearchBody) error {
 		b.Suggest = suggest
 		return err
+	}
+}
+
+type Aggregation interface {
+	GetAggregationField() string
+}
+
+// An aggregation summarizes your data as metrics, statistics, or other analytics.
+// [Aggregations]: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html
+func WithAggregations(aggregations ...Aggregation) BodyOption {
+	return func(b *SearchBody) error {
+		if b.Aggregations == nil {
+			b.Aggregations = map[string]Aggregation{}
+		}
+		for _, agg := range aggregations {
+			b.Aggregations[agg.GetAggregationField()] = agg
+		}
+		return nil
 	}
 }

--- a/effdsl_test.go
+++ b/effdsl_test.go
@@ -67,6 +67,29 @@ func TestWithPIT(t *testing.T) {
 	assert.Equal(t, expectedBody, string(jsonBody))
 }
 
+func TestWithAggregations(t *testing.T) {
+	expectedBody := `
+		{
+			"aggs":{
+				"terms_aggregation_field":{
+					"terms":{"field":"terms_aggregation_field","size":10}
+				},
+				"stats_aggregation_field":{
+					"stats":{"field":"stats_aggregation_field"}
+				}
+			}
+		}`
+	f := effdsl.WithAggregations(
+		effdsl.TermAggregation("terms_aggregation_field", 10),
+		effdsl.StatsAggregation("stats_aggregation_field"),
+	)
+	body := effdsl.SearchBody{}
+	f(&body)
+	jsonBody, err := json.Marshal(body)
+	assert.Nil(t, err)
+	assert.JSONEq(t, expectedBody, string(jsonBody))
+}
+
 func TestDefindeQ1(t *testing.T) {
 	expectedBody := `
 	{
@@ -180,6 +203,11 @@ func TestDefindeQ1(t *testing.T) {
 		],
 		"collapse":{
 		   "field":"field_to_collapse_by"
+		},
+		"aggs":{
+			"terms_aggregation_field":{
+				"terms":{"field":"terms_aggregation_field","size":10}
+			}
 		}
 	 }
 	`
@@ -218,6 +246,9 @@ func TestDefindeQ1(t *testing.T) {
 			effdsl.SortClause("_score", effdsl.SORT_DEFAULT),
 		),
 		effdsl.WithCollpse("field_to_collapse_by"),
+		effdsl.WithAggregations(
+			effdsl.TermAggregation("terms_aggregation_field", 10),
+		),
 	)
 	assert.Nil(t, err)
 	jsonBody, err := json.Marshal(body)

--- a/search_aggregation.go
+++ b/search_aggregation.go
@@ -1,0 +1,68 @@
+package effdsl
+
+import (
+	"encoding/json"
+)
+
+const (
+	AggregationTypeTerms string = "terms"
+	AggregationTypeStats string = "stats"
+)
+
+type aggregation struct {
+	Field           string
+	aggregationType string
+}
+
+func (a aggregation) MarshalJSON() ([]byte, error) {
+	return json.Marshal(M{
+		a.aggregationType: M{
+			"field": a.GetAggregationField(),
+		},
+	})
+}
+
+func (a aggregation) GetAggregationField() string {
+	return a.Field
+}
+
+type TermsAggregationS struct {
+	aggregation
+	Size *int
+}
+
+func (t TermsAggregationS) MarshalJSON() ([]byte, error) {
+
+	params := M{
+		"field": t.GetAggregationField(),
+	}
+	if t.Size != nil {
+		params["size"] = t.Size
+	}
+	return json.Marshal(M{
+		t.aggregationType: params,
+	})
+}
+
+func TermAggregation(field string, size ...int) TermsAggregationS {
+	termsAgg := TermsAggregationS{aggregation: aggregation{
+		Field:           field,
+		aggregationType: AggregationTypeTerms,
+	}}
+	if len(size) > 0 {
+		termsAgg.Size = &size[0]
+	}
+	return termsAgg
+}
+
+type StatsAggregationS struct {
+	aggregation
+	Size *int
+}
+
+func StatsAggregation(field string) StatsAggregationS {
+	return StatsAggregationS{aggregation: aggregation{
+		Field:           field,
+		aggregationType: AggregationTypeStats,
+	}}
+}

--- a/search_aggregation_test.go
+++ b/search_aggregation_test.go
@@ -1,0 +1,34 @@
+package effdsl_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/sdqri/effdsl/v2"
+)
+
+func TestTermsAggregation(t *testing.T) {
+	expectedBody := `{"terms":{"field":"fake_field"}}`
+	termsAggregation := effdsl.TermAggregation("fake_field")
+	jsonBody, err := json.Marshal(termsAggregation)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBody, string(jsonBody))
+}
+
+func TestTermsAggregationWithSize(t *testing.T) {
+	expectedBody := `{"terms":{"field":"fake_field","size":10}}`
+	termsAggregation := effdsl.TermAggregation("fake_field", 10)
+	jsonBody, err := json.Marshal(termsAggregation)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBody, string(jsonBody))
+}
+
+func TestStatsAggregation(t *testing.T) {
+	expectedBody := `{"stats":{"field":"fake_field"}}`
+	termsAggregation := effdsl.StatsAggregation("fake_field")
+	jsonBody, err := json.Marshal(termsAggregation)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBody, string(jsonBody))
+}


### PR DESCRIPTION
## Add aggregation support for queries

An aggregation summarizes your data as metrics, statistics, or other analytics.
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations.html

## Description

Started by implementing two most common used aggregations – [terms bucket](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html) and [stats metric aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-stats-aggregation.html).
Other aggregations type could be implemented by extending AggregationInterface

- [ ] Bug fix
- [x] Feature addition
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Other (please explain):

## Related Issue

<!-- If this PR addresses an issue, please link it. For example, `Fixes #123`. -->

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that ensure my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

---

<!-- Please remove any sections that are not applicable to your PR. -->
