### PR TITLE
Add multimatch query support

### DIFF
--- a/queries/multimatchquery/multimatch_query.go
+++ b/queries/multimatchquery/multimatch_query.go
@@ -1,0 +1,156 @@
+package multimatchquery
+
+import (
+	"encoding/json"
+
+	"github.com/sdqri/effdsl/v2"
+)
+
+type MultiMatchQueryS struct {
+	Query                           string         `json:"query"`                                         // (Required, string) Query text to search for.
+	Fields                          []string       `json:"fields,omitempty"`                              // (Optional, []string) Fields to search.
+	Type                            MultiMatchType `json:"type,omitempty"`                                // (Optional, string) Type of multi match query.
+	Operator                        Operator       `json:"operator,omitempty"`                            // (Optional, string) Operator used to combine terms.
+	Analyzer                        string         `json:"analyzer,omitempty"`                            // (Optional, string) Analyzer to use for the query.
+	Slop                            int            `json:"slop,omitempty"`                                // (Optional, integer) Maximum positions allowed between matching tokens.
+	Fuzziness                       string         `json:"fuzziness,omitempty"`                           // (Optional, string) Fuzziness for fuzzy matching.
+	PrefixLength                    int            `json:"prefix_length,omitempty"`                       // (Optional, integer) Prefix length for fuzzy matching.
+	MaxExpansions                   int            `json:"max_expansions,omitempty"`                      // (Optional, integer) Max expansions for fuzzy queries.
+	MinimumShouldMatch              string         `json:"minimum_should_match,omitempty"`                // (Optional, string) Minimum should match constraint.
+	TieBreaker                      float64        `json:"tie_breaker,omitempty"`                         // (Optional, float) Tie breaker for scoring.
+	Lenient                         bool           `json:"lenient,omitempty"`                             // (Optional, bool) Leniency for parsing query.
+	ZeroTermsQuery                  ZeroTerms      `json:"zero_terms_query,omitempty"`                    // (Optional, string) Handling zero terms.
+	AutoGenerateSynonymsPhraseQuery bool           `json:"auto_generate_synonyms_phrase_query,omitempty"` // (Optional, bool)
+}
+
+func (mq MultiMatchQueryS) QueryInfo() string {
+	return "Multi match query"
+}
+
+func (mq MultiMatchQueryS) MarshalJSON() ([]byte, error) {
+	type MultiMatchQueryBase MultiMatchQueryS
+	return json.Marshal(
+		effdsl.M{
+			"multi_match": (MultiMatchQueryBase)(mq),
+		},
+	)
+}
+
+type MultiMatchQueryOption func(*MultiMatchQueryS)
+
+func WithFields(fields ...string) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.Fields = fields
+	}
+}
+
+func WithType(t MultiMatchType) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.Type = t
+	}
+}
+
+func WithOperator(op Operator) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.Operator = op
+	}
+}
+
+func WithAnalyzer(analyzer string) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.Analyzer = analyzer
+	}
+}
+
+func WithSlop(slop int) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.Slop = slop
+	}
+}
+
+func WithFuzziness(fuzziness string) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.Fuzziness = fuzziness
+	}
+}
+
+func WithPrefixLength(prefixLength int) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.PrefixLength = prefixLength
+	}
+}
+
+func WithMaxExpansions(maxExpansions int) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.MaxExpansions = maxExpansions
+	}
+}
+
+func WithMinimumShouldMatch(msm string) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.MinimumShouldMatch = msm
+	}
+}
+
+func WithTieBreaker(tieBreaker float64) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.TieBreaker = tieBreaker
+	}
+}
+
+func WithLenient(lenient bool) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.Lenient = lenient
+	}
+}
+
+func WithZeroTermsQuery(ztq ZeroTerms) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.ZeroTermsQuery = ztq
+	}
+}
+
+func WithAutoGenerateSynonymsPhraseQuery(agspq bool) MultiMatchQueryOption {
+	return func(query *MultiMatchQueryS) {
+		query.AutoGenerateSynonymsPhraseQuery = agspq
+	}
+}
+
+type Operator string
+
+const (
+	OperatorOr  Operator = "or"
+	OperatorAnd Operator = "and"
+)
+
+type MultiMatchType string
+
+const (
+	BestFields   MultiMatchType = "best_fields"
+	MostFields   MultiMatchType = "most_fields"
+	CrossFields  MultiMatchType = "cross_fields"
+	Phrase       MultiMatchType = "phrase"
+	PhrasePrefix MultiMatchType = "phrase_prefix"
+	BoolPrefix   MultiMatchType = "bool_prefix"
+)
+
+type ZeroTerms string
+
+const (
+	None ZeroTerms = "none"
+	All  ZeroTerms = "all"
+)
+
+// MultiMatchQuery creates a multi_match query for provided query text and optional settings.
+func MultiMatchQuery(query string, opts ...MultiMatchQueryOption) effdsl.QueryResult {
+	multiMatchQuery := MultiMatchQueryS{
+		Query: query,
+	}
+	for _, opt := range opts {
+		opt(&multiMatchQuery)
+	}
+	return effdsl.QueryResult{
+		Ok:  multiMatchQuery,
+		Err: nil,
+	}
+}

--- a/queries/multimatchquery/multimatch_query_test.go
+++ b/queries/multimatchquery/multimatch_query_test.go
@@ -1,0 +1,62 @@
+package multimatchquery_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	mmq "github.com/sdqri/effdsl/v2/queries/multimatchquery"
+)
+
+func TestMultiMatchQueryWithNoOptions(t *testing.T) {
+	queryResult := mmq.MultiMatchQuery("quick brown fox")
+	err := queryResult.Err
+	query := queryResult.Ok
+	assert.Nil(t, err)
+	expectedBody := `{"multi_match":{"query":"quick brown fox"}}`
+	jsonBody, err := json.Marshal(query)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBody, string(jsonBody))
+}
+
+func TestMultiMatchQueryWithFieldsAndType(t *testing.T) {
+	queryResult := mmq.MultiMatchQuery(
+		"quick brown fox",
+		mmq.WithFields("title", "message"),
+		mmq.WithType(mmq.BestFields),
+	)
+	err := queryResult.Err
+	query := queryResult.Ok
+	assert.Nil(t, err)
+	expectedBody := `{"multi_match":{"query":"quick brown fox","fields":["title","message"],"type":"best_fields"}}`
+	jsonBody, err := json.Marshal(query)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBody, string(jsonBody))
+}
+
+func TestMultiMatchQueryWithAllOptions(t *testing.T) {
+	queryResult := mmq.MultiMatchQuery(
+		"quick brown fox",
+		mmq.WithFields("title", "message"),
+		mmq.WithType(mmq.MostFields),
+		mmq.WithOperator(mmq.OperatorAnd),
+		mmq.WithAnalyzer("standard"),
+		mmq.WithSlop(2),
+		mmq.WithFuzziness("AUTO"),
+		mmq.WithPrefixLength(1),
+		mmq.WithMaxExpansions(10),
+		mmq.WithMinimumShouldMatch("2"),
+		mmq.WithTieBreaker(0.3),
+		mmq.WithLenient(true),
+		mmq.WithZeroTermsQuery(mmq.All),
+		mmq.WithAutoGenerateSynonymsPhraseQuery(true),
+	)
+	err := queryResult.Err
+	query := queryResult.Ok
+	assert.Nil(t, err)
+	expectedBody := `{"multi_match":{"query":"quick brown fox","fields":["title","message"],"type":"most_fields","operator":"and","analyzer":"standard","slop":2,"fuzziness":"AUTO","prefix_length":1,"max_expansions":10,"minimum_should_match":"2","tie_breaker":0.3,"lenient":true,"zero_terms_query":"all","auto_generate_synonyms_phrase_query":true}}`
+	jsonBody, err := json.Marshal(query)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBody, string(jsonBody))
+}


### PR DESCRIPTION
## Add multimatch query support

[Elasticsearch Official documentation](https://www.elastic.co/docs/reference/query-languages/query-dsl/query-dsl-multi-match-query)

## Description

- [ ] Bug fix
- [x] Feature addition
- [ ] Code refactoring
- [ ] Documentation update
- [ ] Other (please explain):


## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [x] Manual testing

## Checklist

- [ ] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my code.
- [ ] I have made corresponding changes to the documentation.
- [x] I have added tests that ensure my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
